### PR TITLE
Make all cards equal height

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,9 +11,16 @@ a {
 .card-title {
   font-weight: bold;
   margin-bottom: 10px;
+  height: 40px;
 }
 .card-img-top {
-  max-height: 250px;
+  height: 250px;
+  object-fit: cover;
+}
+
+.card-text{
+  overflow: auto;
+  height: 150px;
 }
 .button {
   border: 3px solid #21ffff;


### PR DESCRIPTION
Now all cards will be of equal height.
- Introduced overflow property to _card-text_ class to make cards of equal height
- Used object fit to make images of equal height
Solves #91 
Here is the page after changes
https://revanthgss.github.io/Contributors-portraits/
