### PR TITLE
removed padding property in % in container class cause it was causing…

### DIFF
--- a/style.css
+++ b/style.css
@@ -170,10 +170,6 @@ h3.style-count {
 	color: #ffffff;
 }
 
-.container {
-	padding: 1%;
-}
-
 hr {
 	background-color: aliceblue;
 }


### PR DESCRIPTION
Overflow Y caused by padding property in container element, bootstrap need padding 15px to work with their structure

Container padding was set to 1% in css